### PR TITLE
Fix typo in `--top-n` for GT call

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ function deleteOverlay(overlayPath: string) {
 
 function buildMaestroCommand(app: Application, absOutputJson?: string, topN?: string, globalFormula?: string, globalBuildCommand?: string, globalInstrumentCommand?: string, llmGatewayKey?: string, globalProjectDirectory?: string): string {
     const outputFlag = absOutputJson ? `--output_file ${absOutputJson}` : '';
-    const topNFlag = topN ? `--top_n ${topN}` : '';
+    const topNFlag = topN ? `--top-n ${topN}` : '';
     const buildCommandFlag = app.build_command || globalBuildCommand ? `--build_command "${app.build_command || globalBuildCommand}"` : '';
     const instrumentCommandFlag = app.instrument_command || globalInstrumentCommand ? `--instrument_command "${app.instrument_command || globalInstrumentCommand}"` : '';
     const projectDirFlag = app.project_directory || globalProjectDirectory ? `--project_directory ${app.project_directory || globalProjectDirectory}` : '';


### PR DESCRIPTION
Must fix typo in flag name, otherwise you'll break GT e.g.
![image](https://github.com/user-attachments/assets/4eaad981-ed46-462b-9b6d-6a4277f25049)
